### PR TITLE
配色・配置の変更

### DIFF
--- a/components/layout.tsx
+++ b/components/layout.tsx
@@ -1,7 +1,8 @@
 import Head from 'next/head'
 import Link from 'next/link'
-import { GitHub, Twitter, Rss } from 'react-feather'
+import { GitHub, Twitter, Rss, Sun, Moon } from 'react-feather'
 import { title, desc } from '../site.conifg.json'
+import { useTheme } from 'next-themes'
 
 const baseUrl = process.env.NEXT_PUBLIC_HOST
 
@@ -12,6 +13,7 @@ const Layout = ({
     children: React.ReactNode,
     home?: boolean
   }) => {
+  const { theme, setTheme } = useTheme()
   return (
     <div className="min-h-screen min-w-min max-w-full bg-gray-100 dark:bg-darkbg">
       <Head>
@@ -48,14 +50,14 @@ const Layout = ({
         <h2 className="text-gray-700 dark:text-darktext text-base break-words max-w-xs md:max-w-md text-center">
           {desc}
         </h2>
-        <div className="flex mt-4">
+        <div className="flex mt-8">
           <a
             className="mx-2"
-            href="https://github.com/tagucch/random.tagucch.dev"
+            href="https://random.tagucch.dev/rss/feed.xml"
             target="_blank"
             rel="noopener noreferrer"
           >
-            <GitHub color="black" className="h-8 w-8" strokeWidth="1.5px" />
+            <Rss color="black" className="h-8 w-8" strokeWidth="1.5px" />
           </a>
           <a
             className="mx-2"
@@ -67,12 +69,23 @@ const Layout = ({
           </a>
           <a
             className="mx-2"
-            href="https://random.tagucch.dev/rss/feed.xml"
+            href="https://github.com/tagucch/random.tagucch.dev"
             target="_blank"
             rel="noopener noreferrer"
           >
-            <Rss color="black" className="h-8 w-8" strokeWidth="1.5px" />
+            <GitHub color="black" className="h-8 w-8" strokeWidth="1.5px" />
           </a>
+
+          {/* ライト・ダークモード切り替えボタン */}
+          <div>
+            <button className="mx-2" onClick={() => setTheme('light')}>
+              <Sun color="black" className="h-8 w-8" strokeWidth="1.5px" />
+            </button>
+            <button className="mx-2" onClick={() => setTheme('dark')}>
+              <Moon color="black" className="h-8 w-8" strokeWidth="1.5px" />
+            </button>
+          </div>
+
         </div>
       </header>
       <main className="pb-10 mx-auto">{children}</main>

--- a/components/layout.tsx
+++ b/components/layout.tsx
@@ -77,14 +77,12 @@ const Layout = ({
           </a>
 
           {/* ライト・ダークモード切り替えボタン */}
-          <div>
-            <button className="mx-2" onClick={() => setTheme('light')}>
-              <Sun color="black" className="h-8 w-8" strokeWidth="1.5px" />
-            </button>
-            <button className="mx-2" onClick={() => setTheme('dark')}>
-              <Moon color="black" className="h-8 w-8" strokeWidth="1.5px" />
-            </button>
-          </div>
+          <button className="mx-2" onClick={() => setTheme('light')}>
+            <Sun color="black" className="h-8 w-8" strokeWidth="1.5px" />
+          </button>
+          <button className="mx-2" onClick={() => setTheme('dark')}>
+            <Moon color="black" className="h-8 w-8" strokeWidth="1.5px" />
+          </button>
 
         </div>
       </header>

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "date-fns": "^2.16.1",
     "gray-matter": "^4.0.2",
     "next": "^10.0.3",
+    "next-themes": "^0.0.15",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-feather": "^2.0.9",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,8 +1,13 @@
 import { AppProps } from 'next/app'
 import '../styles/global.css'
+import { ThemeProvider } from 'next-themes'
 
 function MyApp({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />
+  return (
+    <ThemeProvider attribute="class">
+      <Component {...pageProps} />
+    </ThemeProvider>
+  );
 }
 
 export default MyApp

--- a/pages/posts/[id].tsx
+++ b/pages/posts/[id].tsx
@@ -64,9 +64,9 @@ const Post = ({
         <div className="mt-6 dark:text-darktext-black">
           <Date dateString={postData.date} />
         </div>
-        <div className="mt-2 flex">
+        <div className="flex flex-wrap">
           {postData.tags.map(tag => (
-            <div key={tag} className="bg-noshimehana dark:bg-darkbg-tag text-white dark:text-darktext px-2 py-0.5 mr-2">
+            <div key={tag} className="bg-noshimehana dark:bg-darkbg-tag text-white dark:text-darktext px-2 py-0.5 mt-2 mr-2">
               <Link href={`/tags/${tag}`}>
                 {tag}
               </Link>

--- a/styles/global.css
+++ b/styles/global.css
@@ -112,22 +112,40 @@ a:hover {
   list-style-position: inside;
 }
 
+/* preタグ 全般設定 */
 .content pre {
-  padding: 0.3rem;
+  padding: 0.3rem 0.7rem;
   margin-bottom: 1rem;
   white-space: pre-wrap;
-  background-color: rgba(209, 213, 219);
 }
-
-.content p > code {
+.content p>code {
   padding: 0.3rem;
   line-height: 1.8rem;
+}
+.content pre>code {
+  line-height: 1.8rem;
+}
+
+/* preタグ ライトモード時 */
+.light .content pre {
+  background-color: rgba(209, 213, 219);
+}
+.light .content p > code {
+  background-color: rgba(209, 213, 219);
+}
+.light .content pre>code {
   background-color: rgba(209, 213, 219);
 }
 
-.content pre > code {
-  line-height: 1.8rem;
-  background-color: rgba(209, 213, 219);
+/* preタグ ダークモード時 */
+.dark .content pre {
+  background-color: rgba(82, 89, 102);
+}
+.dark .content p>code {
+  background-color: rgba(82, 89, 102);
+}
+.dark .content pre>code {
+  background-color: rgba(82, 89, 102);
 }
 
 .content p {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   purge: ['./pages/**/*.{js,ts,jsx,tsx}', './components/**/*.{js,ts,jsx,tsx}'],
-  darkMode: 'media', // OSの設定に基づいてダークモードを適用する
+  darkMode: 'class', // ユーザが手動でライトorダークモードに切り替える
   theme: {
     backgroundColor: theme => ({
       ...theme('colors'),

--- a/yarn.lock
+++ b/yarn.lock
@@ -1885,6 +1885,11 @@ native-url@0.3.4:
   dependencies:
     querystring "^0.2.0"
 
+next-themes@^0.0.15:
+  version "0.0.15"
+  resolved "https://registry.yarnpkg.com/next-themes/-/next-themes-0.0.15.tgz#ab0cee69cd763b77d41211f631e108beab39bf7d"
+  integrity sha512-LTmtqYi03c4gMTJmWwVK9XkHL7h0/+XrtR970Ujvtu3s0kZNeJN24aJsi4rkZOI8i19+qq6f8j+8Duwy5jqcrQ==
+
 next@^10.0.3:
   version "10.2.3"
   resolved "https://registry.yarnpkg.com/next/-/next-10.2.3.tgz#5aa058a63626338cea91c198fda8f2715c058394"


### PR DESCRIPTION
・#8 ライト/ダークモード切り替えボタンを追加しました
（自動でOSの設定に合わせなくなりました）
・ダークモード時のpreタグの配色を設定しました
・preタグの左右の余白を広くしました
・ヘッダ アイコンの並び順を変更しました（猫が中央にいると良いため）
・ヘッダ アイコンのmargin-topを広くしました
・記事内のタグにflex-wrapを設定しました

※配色切換えに使ったもの → next-themes
  https://github.com/pacocoursey/next-themes
※デフォルトの配色をOSに合わせる方法は調査中
  現状、最後に選択したカラーモードが記憶されるっぽい