### PR TITLE
Prism.jsでシンタックスハイライトを行うようにする

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "gray-matter": "^4.0.2",
     "next": "^11.1.1",
     "next-themes": "^0.0.15",
+    "prismjs": "^1.24.1",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-feather": "^2.0.9",
@@ -21,6 +22,7 @@
   },
   "devDependencies": {
     "@types/node": "^14.14.10",
+    "@types/prismjs": "^1.16.6",
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",
     "autoprefixer": "^10.2.4",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -3,6 +3,13 @@ import '../styles/global.css'
 import 'prismjs/themes/prism-solarizedlight.css'
 import { ThemeProvider } from 'next-themes'
 
+// (async () => {
+//   if (theme === 'light') {
+//     await import (/* webpackChunkName: "prismjs/themes/prism-tomorrow.css" */ 'prismjs/themes/prism-tomorrow.css')
+//   }
+
+// })()
+
 function MyApp({ Component, pageProps }: AppProps) {
   return (
     <ThemeProvider attribute="class">

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,5 +1,6 @@
 import { AppProps } from 'next/app'
 import '../styles/global.css'
+import 'prismjs/themes/prism-solarizedlight.css'
 import { ThemeProvider } from 'next-themes'
 
 function MyApp({ Component, pageProps }: AppProps) {

--- a/pages/posts/[id].tsx
+++ b/pages/posts/[id].tsx
@@ -1,5 +1,6 @@
 import Head from 'next/head'
 import Link from 'next/link'
+import Prism from 'prismjs'
 import { useEffect } from 'react'
 import {
   GetStaticProps,
@@ -29,6 +30,10 @@ const Post = ({
   }
 }) => {
   useEffect(() => {
+    // prism.jsでのシンタックスハイライト
+    Prism.highlightAll()
+
+    // Twitterのwidget展開
     const s = document.createElement("script");
     s.setAttribute("src", "https://platform.twitter.com/widgets.js");
     s.setAttribute("async", "true");

--- a/yarn.lock
+++ b/yarn.lock
@@ -201,6 +201,11 @@
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
 
+"@types/prismjs@^1.16.6":
+  version "1.16.6"
+  resolved "https://registry.yarnpkg.com/@types/prismjs/-/prismjs-1.16.6.tgz#377054f72f671b36dbe78c517ce2b279d83ecc40"
+  integrity sha512-dTvnamRITNqNkqhlBd235kZl3KfVJQQoT5jkXeiWSBK7i4/TLKBNLV0S1wOt8gy4E2TY722KLtdmv2xc6+Wevg==
+
 "@types/prop-types@*":
   version "15.7.3"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
@@ -2629,6 +2634,11 @@ pretty-hrtime@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz#b7e3ea42435a4c9b2759d99e0f201eb195802ee1"
   integrity sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=
+
+prismjs@^1.24.1:
+  version "1.24.1"
+  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.24.1.tgz#c4d7895c4d6500289482fa8936d9cdd192684036"
+  integrity sha512-mNPsedLuk90RVJioIky8ANZEwYm5w9LcvCXrxHlwf4fNVSn8jEipMybMkWUyyF0JhnC+C4VcOVSBuHRKs1L5Ow==
 
 process-nextick-args@~2.0.0:
   version "2.0.1"


### PR DESCRIPTION
# Prism.js

[Prism](https://prismjs.com/index.html)

シンタックスハイライトをPrism.jsで行うようにする。

## ライトモードとダークモードの出し分け

`next-themes`でダークモードの管理をしているので、ライトモードとダークモードでimportするCSSを分けたかったが、dynamic importでうまくやろうとしたもののうまくいかなかったので、いったんライトモードもダークモードも`prism-solarizedlight`でシンタックスハイライトするようにした。

dynamic importはnode_modulesのライブラリはできなさそうで、独自のファイルならできそうなので、

```dark.js
import 'prismjs/themes/prism-dark.css'
```

と

```light.js
import 'prismjs/themes/prism-twilight.css'
```

みたいに、PrismのCSSを実行するだけのJSファイルをライトモードとダークモードそれぞれで作り、それをdynamic importしたらいけるんじゃない？というジャストアイデアを思いついたのでここに残しておく。

## 具体的な色合い

### ライトモード

![スクリーンショット 2021-09-10 1 30 57](https://user-images.githubusercontent.com/19406706/132726982-ba4332f9-dfd2-4140-bee8-cde15b4bd044.png)

### ダークモード

![スクリーンショット 2021-09-10 1 30 47](https://user-images.githubusercontent.com/19406706/132727007-dd6c3826-49d7-491a-9293-b6294a1279ee.png)

やっぱりダークモードがちょっと見にくい

## 参考

[Next\.js \+ Prism\.jsでコードのSyntax Highlightをする](https://sunday-morning.app/posts/2020-12-15-next-js-prism-js-syntax-highlight)
[Using Prism\.js in a Next\.js site](https://frendly.dev/posts/using-prism-js-in-next-js)
[import \- JavaScript \| MDN](https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Statements/import#dynamic_imports)
[動的インポート \- TypeScript Deep Dive 日本語版](https://typescript-jp.gitbook.io/deep-dive/project/dynamic-import-expressions)
[Dynamic Import Expressions and webpack 2 Code Splitting integration with TypeScript 2\.4 \| José Quinto](https://blog.josequinto.com/2017/06/29/dynamic-import-expressions-and-webpack-code-splitting-integration-with-typescript-2-4/#Overview)