### PR TITLE
Prism.jsの切り戻し

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "gray-matter": "^4.0.2",
     "next": "^11.1.1",
     "next-themes": "^0.0.15",
-    "prismjs": "^1.24.1",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-feather": "^2.0.9",
@@ -22,7 +21,6 @@
   },
   "devDependencies": {
     "@types/node": "^14.14.10",
-    "@types/prismjs": "^1.16.6",
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",
     "autoprefixer": "^10.2.4",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,14 +1,6 @@
 import { AppProps } from 'next/app'
 import '../styles/global.css'
-import 'prismjs/themes/prism-solarizedlight.css'
 import { ThemeProvider } from 'next-themes'
-
-// (async () => {
-//   if (theme === 'light') {
-//     await import (/* webpackChunkName: "prismjs/themes/prism-tomorrow.css" */ 'prismjs/themes/prism-tomorrow.css')
-//   }
-
-// })()
 
 function MyApp({ Component, pageProps }: AppProps) {
   return (

--- a/pages/posts/[id].tsx
+++ b/pages/posts/[id].tsx
@@ -1,8 +1,5 @@
 import Head from 'next/head'
 import Link from 'next/link'
-import Prism from 'prismjs'
-import 'prismjs/components/prism-typescript'
-import 'prismjs/components/prism-jsx'
 import { useEffect } from 'react'
 import {
   GetStaticProps,
@@ -32,9 +29,6 @@ const Post = ({
   }
 }) => {
   useEffect(() => {
-    // prism.jsでのシンタックスハイライト
-    Prism.highlightAll()
-
     // Twitterのwidget展開
     const s = document.createElement("script");
     s.setAttribute("src", "https://platform.twitter.com/widgets.js");

--- a/yarn.lock
+++ b/yarn.lock
@@ -201,11 +201,6 @@
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
 
-"@types/prismjs@^1.16.6":
-  version "1.16.6"
-  resolved "https://registry.yarnpkg.com/@types/prismjs/-/prismjs-1.16.6.tgz#377054f72f671b36dbe78c517ce2b279d83ecc40"
-  integrity sha512-dTvnamRITNqNkqhlBd235kZl3KfVJQQoT5jkXeiWSBK7i4/TLKBNLV0S1wOt8gy4E2TY722KLtdmv2xc6+Wevg==
-
 "@types/prop-types@*":
   version "15.7.3"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
@@ -2634,11 +2629,6 @@ pretty-hrtime@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz#b7e3ea42435a4c9b2759d99e0f201eb195802ee1"
   integrity sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=
-
-prismjs@^1.24.1:
-  version "1.24.1"
-  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.24.1.tgz#c4d7895c4d6500289482fa8936d9cdd192684036"
-  integrity sha512-mNPsedLuk90RVJioIky8ANZEwYm5w9LcvCXrxHlwf4fNVSn8jEipMybMkWUyyF0JhnC+C4VcOVSBuHRKs1L5Ow==
 
 process-nextick-args@~2.0.0:
   version "2.0.1"


### PR DESCRIPTION
# 切り戻し

Prism.jsの導入後に以下のような問題が起きた

- シンタックスハイライトが機能しない
- Twitterのwidget展開ができない

これらはローカル開発環境では問題なく動作するが、本番環境ではうまくいっていなかった。

念のためローカルで`yarn build`して成果物を確認してみたが、Twitterのwidget展開はされていたし、シンタックスハイライトに必要な`language-ts`のようなクラス名もついていた(本番環境ではこのクラス名がついていなかった)

# 切り戻しの切り戻し

#32 のVercelのpreviewを見たところ、なぜかPrism.jsのシンタックスハイライトが直っていたので切り戻さなくてもよくなったので閉じます