### PR TITLE
remark-htmlのアップデートに伴い{ sanitize: false }が必要になったっぽい

### DIFF
--- a/lib/posts.ts
+++ b/lib/posts.ts
@@ -93,7 +93,7 @@ export const getPostData = async (id: string) => {
   const matterResult = matter(fileContents)
 
   const processedContent = await remark()
-    .use(html)
+    .use(html, { sanitize: false })
     .process(matterResult.content)
   
   const contentHtml = processedContent.toString()


### PR DESCRIPTION
#29 によってremark-htmlがアップデートされたんだけど、リリースノートを見たらunsafeなHTMLをパースするためには`{ sanitize: false }`というオプションを渡さないといけないらしい。

これがTwitterのwidget展開ができなくなった原因かもしれないので、`{ sanitize: false }`を渡してみる。