### PR TITLE
fix: ライトモードなのにセレクトボックスのデフォルトカラーがダークモードの色になっている問題の修正

### DIFF
--- a/components/singleSelect.tsx
+++ b/components/singleSelect.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react'
 import { useTheme } from 'next-themes'
 import Select, { StylesConfig } from 'react-select'
 
@@ -11,7 +12,11 @@ const SingleSelect = ({
   onChange: (selectedOption: { label: string, value: string }) => void
 }) => {
   const { theme } = useTheme()
-  const isLightMode = theme === 'light'
+  const [isLightMode, setIsLightMode] = useState(true)
+  useEffect(() => {
+    const isLightMode = theme === 'light'
+    setIsLightMode(isLightMode)
+  })
   const customStyles: StylesConfig = {
     control: (styles) => {
       if (isLightMode) return styles

--- a/components/singleSelect.tsx
+++ b/components/singleSelect.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useLayoutEffect, useState } from 'react'
 import { useTheme } from 'next-themes'
 import Select, { StylesConfig } from 'react-select'
 
@@ -13,7 +13,7 @@ const SingleSelect = ({
 }) => {
   const { theme } = useTheme()
   const [isLightMode, setIsLightMode] = useState(true)
-  useEffect(() => {
+  useLayoutEffect(() => {
     const isLightMode = theme === 'light'
     setIsLightMode(isLightMode)
   })

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -12,7 +12,10 @@ import { ThemeProvider } from 'next-themes'
 
 function MyApp({ Component, pageProps }: AppProps) {
   return (
-    <ThemeProvider attribute="class">
+    <ThemeProvider
+      attribute="class"
+      defaultTheme="system"
+    >
       <Component {...pageProps} />
     </ThemeProvider>
   );


### PR DESCRIPTION
resolve #46 

ライトモードなのにreact-selectのセレクトボックスがダークモードになっている問題の解決。
ブラウザでの初回ロード時に発生し、一度セレクトボックスをクリックすると以降正しく表示されるようになるという症状だった。
ライトモードかどうかを`useState`で持ち、`useEffect`でライトモードかどうかをセットすることで解決。